### PR TITLE
Add support for VCF's with no `SIRENS` entries

### DIFF
--- a/SETTINGS.lua
+++ b/SETTINGS.lua
@@ -45,8 +45,14 @@ SETTINGS.plugins_installed = false
 ---------------------VCF FILES---------------------
 SETTINGS.VCF_Files = {
 	'DEFAULT.xml',
+	'NO_SIRENS.xml',
 }
 
 SETTINGS.VCF_Assignments = {
+	-- Default Horn and Sirens
+	-- E.g. Emergency vehicles
 	['DEFAULT'] = { 1 },
+	-- Default Horn and NO Sirens
+	-- E.g. Non-emergency vehicles with warning lighting, such as tow trucks
+	['NO_SIRENS'] = { 2 },
 }

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -781,7 +781,7 @@ function MainThread()
 								end
 								AUDIO:ResetActivityTimer()
 							------ TOG LX SIREN ------
-							elseif IsDisabledControlJustReleased(0, 19) then
+							elseif IsDisabledControlJustReleased(0, 19) and #SIRENS > 0 then
 								if state_lxsiren[veh] == 0 then
 									if IsVehicleSirenOn(veh) then
 										local new_tone = nil
@@ -815,7 +815,7 @@ function MainThread()
 								AUDIO:ResetActivityTimer()
 								count_broadcast_timer = delay_broadcast_timer
 							-- AUXILIARY
-							elseif IsDisabledControlJustReleased(0, 172) and not IsMenuOpen() then
+							elseif IsDisabledControlJustReleased(0, 172) and not IsMenuOpen() and #SIRENS > 0 then
 								if state_auxiliary[veh] == 0 then
 									if IsVehicleSirenOn(veh) then
 										AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
@@ -833,7 +833,7 @@ function MainThread()
 								count_broadcast_timer = delay_broadcast_timer
 							end
 							-- CYCLE LX SRN TONES
-							if state_lxsiren[veh] > 0 then
+							if state_lxsiren[veh] > 0 and #SIRENS > 0 then
 								if IsDisabledControlJustReleased(0, 80) then
 									AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
 									HUD:SetItemState('horn', false)
@@ -845,7 +845,7 @@ function MainThread()
 							end
 
 							-- MANU
-							if state_lxsiren[veh] < 1 then
+							if state_lxsiren[veh] < 1 and #SIRENS > 0 then
 								if IsDisabledControlPressed(0, 80) then
 									AUDIO:ResetActivityTimer()
 									actv_manu = true
@@ -856,7 +856,7 @@ function MainThread()
 									end
 									actv_manu = false
 								end
-							else
+							elseif #SIRENS > 0 then
 								if actv_manu then
 									HUD:SetItemState('siren', false)
 								end
@@ -864,7 +864,7 @@ function MainThread()
 							end
 
 							-- TOG RUMBLER (LSHIFT+E)
-							if LVC.rumbler and LVC.rumbler_enabled and IsControlPressed(0, 131) and MCTRL:GetSirenMode() ~= MCTRL.LOCAL then
+							if LVC.rumbler and LVC.rumbler_enabled and IsControlPressed(0, 131) and MCTRL:GetSirenMode() ~= MCTRL.LOCAL and #SIRENS > 0 then
 								if IsDisabledControlJustReleased(0, 86) and state_lxsiren[veh] > 0 then
 									MCTRL:SetTempRumblerMode(true)				
 								end
@@ -893,7 +893,7 @@ function MainThread()
 								end
 							end
 
-							if AUDIO.manual_sfx and state_lxsiren[veh] == 0 then
+							if AUDIO.manual_sfx and state_lxsiren[veh] == 0 and #SIRENS > 0 then
 								if IsDisabledControlJustPressed(0, 80) then
 									AUDIO:Play('Press', AUDIO.upgrade_volume)
 								end

--- a/VCF/NO_SIRENS.xml
+++ b/VCF/NO_SIRENS.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	LVC VEHICLE CONFIGURATION FILE
+
+	Vehicles assigned this VCF will be able to use an airhorn and all plugins (i.e. traffic controller),
+	without being able to use any siren functions. The hud will show, but the siren light will not change.
+-->
+<vcfroot Faction="NONE" Author="Christopher M." >
+	<!-- HORN AND SIREN TONES -->
+	<TONES>
+		<HORNS>
+		<!--1==================================================================================================================================================================================================================-->
+			<HORN Name="AIRHORN" 	Option="1"	ResidentString=	"SIRENS_AIRHORN"
+												String=			"" 		Ref=	"" 	Bank= ""
+												RumblerString=	""	RumblerRef=	"" 	RumblerBank=""/>
+		<!--===================================================================================================================================================================================================================-->
+		</HORNS>
+		<SIRENS/>
+	</TONES>
+	<!-- SIREN OPTIONS -->	
+	<SIREN_CONFIG>
+		<Horn ToneID="1"/>
+		<Primary_Manual ToneID="0"/>
+		<Secondary_Manual ToneID="0"/>
+		<Auxiliary ToneID="0"/>
+		<Airhorn_Intrp Enabled="true"/>
+		<Reset_Standby Enabled="true"/>
+		<Park_Kill Enabled="true"/>
+		<Peer_Override Enabled="false"/>
+		<Local_Override Enabled="false"/>
+		<Rumbler Enabled="false"/>
+	</SIREN_CONFIG>
+	<!-- HUD SETTINGS -->	
+	<HUD Enabled="true" Backlight_Mode="1"/>
+	<!-- AUDIO Settings -->
+	<AUDIO>
+		<Radio Enabled="true"/>				
+		<Airhorn_SFX Enabled="true"/>
+		<Manual_SFX Enabled="true"/>
+		<Hazards_SFX Enabled="true"/>
+		<Activity_Reminder_Interval_Index Val="1"/>
+		<Scheme_Index Val="1"/>
+		<SCHEMES>
+			<SCHEME String="SSP2000"/>
+			<SCHEME String="SSP3000"/>
+			<SCHEME String="Cencom"/>
+			<SCHEME String="ST300"/>
+			<SCHEME String="Code3-MCB"/>
+		</SCHEMES>
+		<On_Volume Val="0.5"/>
+		<Off_Volume Val="0.7"/>
+		<Upgrade_Volume Val="0.5"/>
+		<Downgrade_Volume Val="0.7"/>
+		<Hazards_Volume Val="0.09"/>
+		<Activity_Reminder_Volume Val="0.09"/>
+	</AUDIO>
+	<!-- MENU PERMISSIONS -->
+	<MENU>
+		<Menu_Access Enabled='false'/>
+		<Menu_Main_Siren_Settings Enabled="true"/>
+		<Toggle_Peer_Override Enabled="true"/>	
+		<Toggle_Local_Override Enabled="true"/>
+		<Toggle_Airhorn_Intrp Enabled="true"/>
+		<Toggle_Reset_Standby Enabled="true"/>
+		<Custom_Tone_Options Enabled="true"/>
+		<Custom_Manual Enabled="true"/>
+		<Custom_Auxiliary Enabled="true"/>
+		<Toggle_Park_Kill Enabled="true"/>
+		<Menu_HUD_Settings Enabled="true"/>
+		<Toggle_HUD Enabled="true"/>
+		<Custom_Backlight_Mode Enabled="true"/>
+		<Menu_Audio_Settings Enabled="true"/>
+		<Toggle_Radio Enabled="true"/>
+		<Custom_Scheme Enabled="true"/>
+		<Toggle_Clicks Enabled="true"/>
+		<Custom_Activity_Reminder Enabled="true"/>
+		<Menu_Plugins Enabled="true"/>
+	</MENU>
+	<PLUGINS>
+
+	</PLUGINS>
+</vcfroot>


### PR DESCRIPTION
Adds additional checks to support VCF files that do not contain `SIRENS` entries. Outside of good practice and preventing accidental errors, the use case for this might be for Civlian VCF entries, such as for non-emergency vehicles with warning lights. An example might be a tow truck that would benefit from the Traffic Advisor plugin, but does not need a siren.