### PR TITLE
Make audio bank limit a config option.

### DIFF
--- a/SETTINGS.lua
+++ b/SETTINGS.lua
@@ -22,6 +22,11 @@ SETTINGS.locked_press_count = 5
 SETTINGS.reminder_rate = 10
 --	How often, in luxart key presses, to remind you that your siren controller is locked.
 
+----------------SIREN LIMIT SETTINGS---------------
+SETTINGS.siren_limit = 7
+-- Currently only 7 audio banks can be loaded at a time due to a game limitation.
+--		If you have other resources that require an audio bank to be loaded you should keep this value under 7.
+
 --------------CUSTOM MANU/HORN/SIREN---------------
 SETTINGS.main_siren_set_register_keys_set_defaults = true
 --	Enables RegisterKeyMapping for all main_allowed_tones and sets the default keys to numrow 1-0.

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -317,10 +317,10 @@ function ReqAudioBank(bank)
 		return
 	end
 
-	while #loaded_banks > 6 do
-		ReleaseNamedScriptAudioBank(loaded_banks[7])
+	while #loaded_banks >= SETTINGS.siren_limit do
+		ReleaseNamedScriptAudioBank(loaded_banks[SETTINGS.siren_limit])
 		ReleaseScriptAudioBank()
-		table.remove(loaded_banks, 7)
+		table.remove(loaded_banks, SETTINGS.siren_limit)
 	end
 	for i,v in ipairs(loaded_banks) do
 		if v == bank then


### PR DESCRIPTION
A lot of servers use other resources which also require an audio bank to be loaded. The current implementation has a hard-coded limit which prevents any other banks from being loaded. This will allow server owners to tweak it based on their needs with a simple config option. Functionality remains the exact same.